### PR TITLE
Removed an extra `x` iteration from `update()`

### DIFF
--- a/addons/BitmapFontCutterPlus/cutter.gd
+++ b/addons/BitmapFontCutterPlus/cutter.gd
@@ -50,7 +50,7 @@ func update():
 			font.add_texture(TextureToCut)
 			font.height = GlyphSize.y
 			for y in range(ty):
-				for x in range(tx+1):
+				for x in range(tx):
 					var l = 0
 					var character_width = GlyphSize.x
 					


### PR DESCRIPTION
This was causing every nth character to be blank.

e.g. if characters are 10px wide and the texture is 100 pixels wide, the 11th character was blank instead of the first block from the next row